### PR TITLE
Change .codecov to be consistent with diffpy.utils's

### DIFF
--- a/{{ cookiecutter.repo_name }}/.codecov.yml
+++ b/{{ cookiecutter.repo_name }}/.codecov.yml
@@ -1,10 +1,34 @@
-# show coverage in CI status, not as a comment.
-comment: off
+# codecov can find this file anywhere in the repo, so we don't need to clutter
+# the root folder.
+#comment: false
+
+codecov:
+  notify:
+    require_ci_to_pass: no
+
 coverage:
   status:
-    project:
-      default:
-        target: auto
     patch:
       default:
+        target: '70'
+        if_no_uploads: error
+        if_not_found: success
+        if_ci_failed: failure
+    project:
+      default: false
+      library:
         target: auto
+        if_no_uploads: error
+        if_not_found: success
+        if_ci_failed: error
+        paths: '!*/tests/.*'
+
+      tests:
+        target: 97.9%
+        paths: '*/tests/.*'
+        if_not_found: success
+
+flags:
+  tests:
+    paths:
+      - tests/


### PR DESCRIPTION
Closes #15
Initial commit to make .codecov consistent with diffpy.utils
Update if_ci_failed from 'failure' to 'error' in coverage since it reports only has 'error' or 'success' options.
<img width="1304" alt="截屏2024-06-20 下午11 49 07" src="https://github.com/Billingegroup/cookiecutter/assets/157993340/9e1c7292-4fe9-420d-991c-d2249a880737">
