### PR TITLE
Add keyword inputs

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,5 +1,8 @@
 {
     "github_org": "diffpy",
+    "keyword_1": "",
+    "keyword_2": "",
+    "keyword_3": "",
     "project_name": "diffpy.my_project",
     "package_dist_name": "{{ cookiecutter.project_name|replace(' ', '-')|lower }}",
     "package_dir_name": "{{ cookiecutter.project_name|replace(' ', '_')|replace('-', '_')|lower }}",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,8 +1,6 @@
 {
     "github_org": "diffpy",
-    "keyword_1": "",
-    "keyword_2": "",
-    "keyword_3": "",
+    "keywords": "",
     "project_name": "diffpy.my_project",
     "package_dist_name": "{{ cookiecutter.project_name|replace(' ', '-')|lower }}",
     "package_dir_name": "{{ cookiecutter.project_name|replace(' ', '_')|replace('-', '_')|lower }}",

--- a/test_utils.py
+++ b/test_utils.py
@@ -11,13 +11,7 @@ p = pexpect.spawn(f"cookiecutter {cc_path}")
 p.expect("github_org .*")
 p.sendline("diffpy")
 
-p.expect("keyword_1 .*")
-p.sendline("")
-
-p.expect("keyword_2 .*")
-p.sendline("")
-
-p.expect("keyword_3 .*")
+p.expect("keywords .*")
 p.sendline("")
 
 p.expect("project_name .*")

--- a/test_utils.py
+++ b/test_utils.py
@@ -11,6 +11,15 @@ p = pexpect.spawn(f"cookiecutter {cc_path}")
 p.expect("github_org .*")
 p.sendline("diffpy")
 
+p.expect("keyword_1 .*")
+p.sendline("")
+
+p.expect("keyword_2 .*")
+p.sendline("")
+
+p.expect("keyword_3 .*")
+p.sendline("")
+
 p.expect("project_name .*")
 p.sendline("diffpy.utils")
 

--- a/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -26,17 +26,11 @@ classifiers = [
         'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX',
         'Operating System :: Unix',
-        {%- if cookiecutter.minimum_supported_python_version|length == 3 -%} # Parse cookiecutter min version variable
-                {%- set min_version = cookiecutter.minimum_supported_python_version[-1] | int -%}
-        {%- elif cookiecutter.minimum_supported_python_version|length == 4 -%}
-                {%- set min_version = cookiecutter.minimum_supported_python_version[-2:] | int -%}
-        {%- else -%}
-                {%- set min_version = 8 -%} # Choose 3.8 as a failsafe
-        {%- endif -%}
+        {%- set min_version = cookiecutter.minimum_supported_python_version.split('.')[1] | int -%}
         {%- for version in [8, 9, 10, 11, 12] -%}
-                {%- if version >= min_version %}
+            {%- if version >= min_version %}
         'Programming Language :: Python :: 3.{{ version }}',
-        {%- endif -%}
+            {%- endif -%}
         {% endfor %}
         'Topic :: Scientific/Engineering :: Physics',
 ]

--- a/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -12,9 +12,8 @@ maintainers = [
   { name="Simon J.L. Billinge group", email="simon.billinge@gmail.com" },
 ]
 description = "{{ cookiecutter.project_short_description }}"
-{%- set keywds = [cookiecutter.keyword_1, cookiecutter.keyword_2, cookiecutter.keyword_3] -%}
-{% set keyword_list = keywds | select('string') | map('trim') | reject('equalto', '') | list %}
-keywords = {{ keyword_list }}
+{%- set keywords_list = (cookiecutter.keywords.split(',') if cookiecutter.keywords.strip() else []) %}
+keywords = {{ keywords_list }}
 readme = "README.rst"
 requires-python = ">=3.9"
 classifiers = [

--- a/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -15,7 +15,7 @@ description = "{{ cookiecutter.project_short_description }}"
 {%- set keywords_list = (cookiecutter.keywords.split(',') if cookiecutter.keywords.strip() else []) %}
 keywords = {{ keywords_list }}
 readme = "README.rst"
-requires-python = ">=3.9"
+requires-python = ">={{ cookiecutter.minimum_supported_python_version }}"
 classifiers = [
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',

--- a/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -12,7 +12,9 @@ maintainers = [
   { name="Simon J.L. Billinge group", email="simon.billinge@gmail.com" },
 ]
 description = "{{ cookiecutter.project_short_description }}"
-keywords = []
+{%- set keywds = [cookiecutter.keyword_1, cookiecutter.keyword_2, cookiecutter.keyword_3] -%}
+{% set keyword_list = keywds | select('string') | map('trim') | reject('equalto', '') | list %}
+keywords = {{ keyword_list }}
 readme = "README.rst"
 requires-python = ">=3.9"
 classifiers = [
@@ -41,8 +43,8 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/{{ cookiecutter.full_name }}/{{ cookiecutter.project_name }}/"
-Issues = "https://github.com/{{ cookiecutter.full_name }}/{{ cookiecutter.project_name }}/issues/"
+Homepage = "https://github.com/{{ cookiecutter.github_org }}/{{ cookiecutter.project_name }}/"
+Issues = "https://github.com/{{ cookiecutter.github_org }}/{{ cookiecutter.project_name }}/issues/"
 
 [tool.setuptools-git-versioning]
 enabled = true


### PR DESCRIPTION
Closes #66, #68 (did a quick fix for this)
The cookiecutter now prompts the user with three keyword questions, which default to blank. The following is the git diff of pyproject.toml with the diffpy.utils description. The only notable difference is single quotes vs double quotes, which is just an artifact of the cookiecutter input and probably can't be easily changed. It shouldn't matter though.

Also, a result of this is that `test_utils.py` had to be updated, so if this is merged everyone should definitely sync right away.

![Screenshot from 2024-06-21 17-37-49](https://github.com/Billingegroup/cookiecutter/assets/32941464/84c7c7a0-9fa2-4a09-bd2f-2d7b4a7f1c02)
