### PR TITLE
Fix spacing in pyproject.toml classifiers

### DIFF
--- a/test_utils.py
+++ b/test_utils.py
@@ -12,7 +12,7 @@ p.expect("github_org .*")
 p.sendline("diffpy")
 
 p.expect("keywords .*")
-p.sendline("")
+p.sendline("text data parsers, wx grid, diffraction objects")
 
 p.expect("project_name .*")
 p.sendline("diffpy.utils")

--- a/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -12,8 +12,12 @@ maintainers = [
   { name="Simon J.L. Billinge group", email="simon.billinge@gmail.com" },
 ]
 description = "{{ cookiecutter.project_short_description }}"
-{%- set keywords_list = (cookiecutter.keywords.split(',') if cookiecutter.keywords.strip() else []) %}
-keywords = {{ keywords_list }}
+{%- set keywords_list = (cookiecutter.keywords.split(',') if cookiecutter.keywords.strip() else []) -%}
+{%- set ns = namespace(keywords_trim = []) -%}
+{%- for keyword in keywords_list -%}
+{%- set _ = ns.keywords_trim.append(keyword.strip()) -%}
+{%- endfor %}
+keywords = {{ ns.keywords_trim }}
 readme = "README.rst"
 requires-python = ">={{ cookiecutter.minimum_supported_python_version }}"
 classifiers = [
@@ -31,7 +35,7 @@ classifiers = [
             {%- if version >= min_version %}
         'Programming Language :: Python :: 3.{{ version }}',
             {%- endif -%}
-        {% endfor %}
+        {%- endfor %}
         'Topic :: Scientific/Engineering :: Physics',
 ]
 


### PR DESCRIPTION
It seems as if the `keywords` were not tested. There was extra spacing in the keywords. 

New diff:
![image](https://github.com/Billingegroup/cookiecutter/assets/59151395/447036f3-e78c-4776-8916-d7ad6dbdb64a)
![image](https://github.com/Billingegroup/cookiecutter/assets/59151395/17cd459c-e465-408a-8f24-b1960431615d)
