### PR TITLE
Add root files

### DIFF
--- a/{{ cookiecutter.repo_name }}/.flake8
+++ b/{{ cookiecutter.repo_name }}/.flake8
@@ -4,9 +4,8 @@ exclude =
     __pycache__,
     build,
     dist,
-    versioneer.py,
-    {{ cookiecutter.package_dir_name }}/_version.py,
     docs/source/conf.py
 max-line-length = 115
 # Ignore some style 'errors' produced while formatting by 'black'
-ignore = E203, W503
+# https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#labels-why-pycodestyle-warnings
+extend-ignore = E203

--- a/{{ cookiecutter.repo_name }}/AUTHORS.rst
+++ b/{{ cookiecutter.repo_name }}/AUTHORS.rst
@@ -1,9 +1,10 @@
 Authors
 =======
-*** EDIT ***
 
+Billinge Group and community contibutors.
 
 Contributors
 ------------
 
-None yet. Why not be the first? See: CONTRIBUTING.rst
+For a list of contributors, visit
+https://github.com/{{ cookiecutter.github_org }}/{{ cookiecutter.repo_name }}/graphs/contributors

--- a/{{ cookiecutter.repo_name }}/LICENSE.rst
+++ b/{{ cookiecutter.repo_name }}/LICENSE.rst
@@ -1,6 +1,7 @@
 BSD 3-Clause License
 
-Copyright (c) {% now 'utc', '%Y' %}, {{ cookiecutter.github_org }}
+Copyright (c) {% now 'utc', '%Y' %}, The Trustees of Columbia Unversity
+in the City of New York.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
- Closes #10
![image](https://github.com/Billingegroup/cookiecutter/assets/59151395/7e30302f-3d59-4917-a929-f05ee6703418)
Fixes link currently in `diffpy.utils` and remove `versioneer`.
 
- Closes #14 
License completely changed to base BSD 3-Clause License.

- Closes #30
![image](https://github.com/Billingegroup/cookiecutter/assets/59151395/ce0b0c48-663d-498c-9742-10741e2edd22)
Rename `AUTHORS.txt` to `AUTHORS.rst` and change contribution blurb.