### PR TITLE
Index for documentation

### DIFF
--- a/test_utils.py
+++ b/test_utils.py
@@ -27,7 +27,7 @@ p.expect("repo_name .*")
 p.sendline("")
 
 p.expect("project_short_description .*")
-p.sendline("")
+p.sendline("general purpose shared utilities for the diffpy libraries")
 
 p.expect("Select minimum_supported_python_version.*")
 p.sendline("3")

--- a/{{ cookiecutter.repo_name }}/doc/source/api/{{ cookiecutter.package_dir_name }}.example_package.rst
+++ b/{{ cookiecutter.repo_name }}/doc/source/api/{{ cookiecutter.package_dir_name }}.example_package.rst
@@ -23,4 +23,3 @@
     :members:
     :undoc-members:
     :show-inheritance:
-

--- a/{{ cookiecutter.repo_name }}/doc/source/api/{{ cookiecutter.package_dir_name }}.example_package.rst
+++ b/{{ cookiecutter.repo_name }}/doc/source/api/{{ cookiecutter.package_dir_name }}.example_package.rst
@@ -1,0 +1,26 @@
+.. _example_package documentation:
+
+{{ cookiecutter.package_dir_name }}.example_package package
+===========================================================
+
+.. automodule:: {{ cookiecutter.package_dir_name }}.example_package
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+{{ cookiecutter.package_dir_name }}.example_package.foo module
+--------------------------------------------------------------
+
+.. automodule::  {{ cookiecutter.package_dir_name }}.example_package.foo
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+{{ cookiecutter.package_dir_name }}.example_package.bar module
+--------------------------------------------------------------
+
+.. automodule:: {{ cookiecutter.package_dir_name }}.example_package.foo
+    :members:
+    :undoc-members:
+    :show-inheritance:
+

--- a/{{ cookiecutter.repo_name }}/doc/source/api/{{ cookiecutter.package_dir_name }}.rst
+++ b/{{ cookiecutter.repo_name }}/doc/source/api/{{ cookiecutter.package_dir_name }}.rst
@@ -24,4 +24,3 @@ Submodules
     :members:
     :undoc-members:
     :show-inheritance:
-

--- a/{{ cookiecutter.repo_name }}/doc/source/api/{{ cookiecutter.package_dir_name }}.rst
+++ b/{{ cookiecutter.repo_name }}/doc/source/api/{{ cookiecutter.package_dir_name }}.rst
@@ -12,6 +12,16 @@ Subpackages
 -----------
 
 .. toctree::
+   {{ cookiecutter.package_dir_name }}.example_package
 
 Submodules
 ----------
+
+{{ cookiecutter.package_dir_name }}.example_submodule module
+------------------------------------------------------------
+
+.. automodule:: {{ cookiecutter.package_dir_name }}.example_submodule
+    :members:
+    :undoc-members:
+    :show-inheritance:
+

--- a/{{ cookiecutter.repo_name }}/doc/source/api/{{ cookiecutter.package_dir_name }}.rst
+++ b/{{ cookiecutter.repo_name }}/doc/source/api/{{ cookiecutter.package_dir_name }}.rst
@@ -1,0 +1,17 @@
+:tocdepth: -1
+
+{{ cookiecutter.project_name }} package
+=======================================
+
+.. automodule:: {{ cookiecutter.package_dir_name }}
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+Subpackages
+-----------
+
+.. toctree::
+
+Submodules
+----------

--- a/{{ cookiecutter.repo_name }}/doc/source/index.rst
+++ b/{{ cookiecutter.repo_name }}/doc/source/index.rst
@@ -1,15 +1,41 @@
-.. Packaging Scientific Python documentation master file, created by
-   sphinx-quickstart on Thu Jun 28 12:35:56 2018.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
+#############################################
+{{ cookiecutter.project_name }} documentation
+#############################################
 
-{{ cookiecutter.project_name }} Documentation
-{{ '=' * (cookiecutter.project_name|length + ' Documentation'|length) }}
+{{ cookiecutter.project_name }} - {{ cookiecutter.project_short_description }}.
 
+| Software version |release|.
+| Last updated |today|.
+
+=======
+Authors
+=======
+
+{{ cookiecutter.project_name }} is developed by Billinge Group
+and its community contributors.
+
+For a detailed list of contributors see
+https://github.com/{{ cookiecutter.github_org }}/{{ cookiecutter.repo_name }}/graphs/contributors.
+
+============
+Installation
+============
+
+See the `README <https://github.com/{{ cookiecutter.github_org }}/{{ cookiecutter.repo_name }}#installation>`_
+file included with the distribution.
+
+=================
+Table of contents
+=================
 .. toctree::
-   :maxdepth: 2
+   :titlesonly:
 
-   installation
-   usage
-   release-history
-   min_versions
+   license
+   release
+
+=======
+Indices
+=======
+
+* :ref:`genindex`
+* :ref:`search`

--- a/{{ cookiecutter.repo_name }}/doc/source/index.rst
+++ b/{{ cookiecutter.repo_name }}/doc/source/index.rst
@@ -32,6 +32,7 @@ Table of contents
 
    license
    release
+   Package API <api/{{ cookiecutter.package_dir_name }}>
 
 =======
 Indices

--- a/{{ cookiecutter.repo_name }}/doc/source/release.rst
+++ b/{{ cookiecutter.repo_name }}/doc/source/release.rst
@@ -1,0 +1,5 @@
+:tocdepth: -1
+
+.. index:: release notes
+
+.. include:: ../../CHANGELOG.rst


### PR DESCRIPTION
Closes #63 
Added `release.rst` that copies the `CHANGELOG.rst` in root.
Change project short description in our test.
![image](https://github.com/Billingegroup/cookiecutter/assets/59151395/0a7fc7aa-e7b5-4cbb-8bda-b0d901088df9)
![image](https://github.com/Billingegroup/cookiecutter/assets/59151395/fcfec8b8-84e2-440b-a87d-c4f3ba0de10c)
![image](https://github.com/Billingegroup/cookiecutter/assets/59151395/33fb599d-b531-4fc7-a8fc-a3826c6a2238)
This image above assumes our `README.rst` has an `installation` section. If we do not want to mandate that, I will just link to the repo.
![image](https://github.com/Billingegroup/cookiecutter/assets/59151395/66109d95-8be8-4609-a34f-2b587892e490)
