### PR TITLE
docker release info

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,92 @@ This should be done only when the above steps are finished.
 4. Run through the documentation online and do the same, fix any last typos and make all the links work.  To do this the documentation must have been correctly built on a merge to main and enabled on the github.io website.  Instructions are [here](https://gitlab.thebillingegroup.com/resources/group-wiki/-/wikis/Maintaining-and-Deploying-Documentation)
 5. When you are are happy to sign off on the release send a Slack message to Simon saying something like "`OK to release diffpy.<package-name>`"
 6. Make sure that the codecov secret is set in the GH actions repository secrets.  Probably Simon will have to do this [here](https://docs.codecov.com/docs/bitbucket-tutorial))
+
+## Docker Release Workflow
+You can use docker to build (and optionally release) Python packages for PyPI. Windows and Linux builds are handled via the dockerfiles, 
+but Mac builds are done using the [Docker-OSX image](https://github.com/sickcodes/Docker-OSX).
+
+### Requirements/Install
+In order to run the docker releaser, you first need to install `docker` as normal. Then, navigate to
+https://github.com/sickcodes/Docker-OSX and install the latest macos image `sickcodes/docker-osx:latest`.
+
+Once this is done, clone the repo https://github.com/Billingegroup/release-scripts
+`cd` into the `docker-releaser` directory and now you are ready to run the `docker_release.py` script as normal.
+
+### Usage
+```
+python docker_release.py <package_name> [-u] [version_number] <min_version> <max_version> <path_to_package>
+```
+Where `-u` is an optional upload flag that requires `version_number` if it is set, `package_name` is the name 
+of the Python package as it is to be released, `min_version` is the minimum Python version (i.e. 3.10),
+`max_version` is the maximum Python version (i.e. 3.12), and `path_to_package` is the
+path to the package directory. If there is only one valid version, put the same number twice.
+
+### Building Only
+If you just want to build the package, you can do as follows. Example for `diffpy.pdffit2`:
+
+```
+python docker_release.py diffpy.pdffit2 3.10 3.12 ~/Documents/dev/diffpy.pdffit2
+```
+
+The build files can be found by running `docker images`
+
+### Build and Upload
+Follow these first steps, from `basic_release.txt`:
+
+#### Prerequisites
+##### Python Build
+`pip install build` or `mamba/conda install conda-forge::python-build`
+
+##### GitHub
+Must first login with GitHub-CLI:
+First, install gh
+
+```
+mamba install gh --channel conda-forge
+```
+
+Then authenticate
+
+```
+gh auth login
+```
+
+Easy choices for login:
+
+? What account do you want to log into? GitHub.com
+
+? What is your preferred protocol for Git operations on this host? HTTPS
+
+? How would you like to authenticate GitHub CLI? Login with a web browser
+
+Then open the link https://github.com/login/device and enter the one-time code
+
+##### PyPi
+First install twine:
+
+```
+pip install twine
+```
+
+and then configure the pypirc file https://packaging.python.org/en/latest/specifications/pypirc/
+
+#### Configuration Variables
+You may put optional configuration variables in a release_config.sh file
+
+
+#### Run
+
+Once these steps are complete, run the docker releaser.
+
+Add the `-u` flag and the associated `version_number`. This example command will both build and upload `diffpy.pdffit2` as
+version `1.5.0`:
+
+```
+python docker_release.py -u 1.5.0 diffpy.pdffit2 3.10 3.12 ~/Documents/dev/diffpy.pdffit2
+```
+
+
 ## Workflow for testing diffpy.utils files
 We are using diffpy.utils as a template
 for building the cookie cutter.  To make sure the cookie cutter

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ This should be done only when the above steps are finished.
 6. Make sure that the codecov secret is set in the GH actions repository secrets.  Probably Simon will have to do this [here](https://docs.codecov.com/docs/bitbucket-tutorial))
 
 ## Docker Release Workflow
-You can use docker to build (and optionally release) Python packages for PyPI. Windows and Linux builds are handled via the dockerfiles, 
+You can use docker to build (and optionally release) Python packages for PyPI. Windows and Linux builds are handled via the dockerfiles,
 but Mac builds are done using the [Docker-OSX image](https://github.com/sickcodes/Docker-OSX).
 
 ### Requirements/Install
@@ -122,7 +122,7 @@ Once this is done, clone the repo https://github.com/Billingegroup/release-scrip
 ```
 python docker_release.py <package_name> [-u] [version_number] <min_version> <max_version> <path_to_package>
 ```
-Where `-u` is an optional upload flag that requires `version_number` if it is set, `package_name` is the name 
+Where `-u` is an optional upload flag that requires `version_number` if it is set, `package_name` is the name
 of the Python package as it is to be released, `min_version` is the minimum Python version (i.e. 3.10),
 `max_version` is the maximum Python version (i.e. 3.12), and `path_to_package` is the
 path to the package directory. If there is only one valid version, put the same number twice.


### PR DESCRIPTION
Add docker release info to instructions (`README.md`) from [this PR](https://github.com/Billingegroup/release-scripts/pull/10). This mirrors the instructions in the `docker-releaser/RELEASE.md` file at the `release-scripts` repo.