### PR TITLE
Add dynamic dependency in pyproject.toml

### DIFF
--- a/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "{{ cookiecutter.package_dist_name }}"
-dynamic=['version']
+dynamic=['version', 'dependencies']
 authors = [
   { name="Simon J.L. Billinge group", email="simon.billinge@gmail.com" },
 ]
@@ -54,6 +54,9 @@ where = ["src"]  # list of folders that contain the packages (["."] by default)
 include = ["*"]  # package names should match these glob patterns (["*"] by default)
 exclude = ["{{ cookiecutter.project_name }}.tests*"]  # exclude packages matching these glob patterns (empty by default)
 namespaces = false  # to disable scanning PEP 420 namespaces (true by default)
+
+[tool.setuptools.dynamic]
+dependencies = {file = ["requirements/run.txt"]}
 
 [tool.black]
 line-length = 115


### PR DESCRIPTION
Closes https://github.com/Billingegroup/cookiecutter/issues/110

This change allows pip users to download all dependencies associated with the package.

@Tieqiong 

Similar PRs made to individual cookiecuttered packages:

- https://github.com/diffpy/diffpy.structure/pull/98
- https://github.com/Billingegroup/bg-mpl-stylesheets/pull/60