### PR TITLE
add a workflow that checks for a news

### DIFF
--- a/{{ cookiecutter.repo_name }}/.github/workflows/check-news-item.yml
+++ b/{{ cookiecutter.repo_name }}/.github/workflows/check-news-item.yml
@@ -1,0 +1,32 @@
+name: Check News Item
+
+on:
+  pull_request_target:
+    branches:
+    - main
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Check News item
+    steps:
+
+      # note: the checkout will pull code from the base branch. This step should not pull code from the merge commit
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: 'pyproject.toml'
+      - run: pip install PyGithub
+      - run: python .github/workflows/check-news.py
+        env:
+          PR_NUMBER: "${{ github.event.number }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_REPOSITORY: "${{ env.GITHUB_REPOSITORY }}"

--- a/{{ cookiecutter.repo_name }}/.github/workflows/check-news.py
+++ b/{{ cookiecutter.repo_name }}/.github/workflows/check-news.py
@@ -1,0 +1,62 @@
+"""Check if the PR has a news item.
+
+Put a warning comment if it doesn't.
+"""
+
+import os
+from fnmatch import fnmatch
+
+from github import Github, PullRequest
+
+
+def get_added_files(pr: PullRequest.PullRequest):
+    print(pr, pr.number)
+    for file in pr.get_files():
+        if file.status == "added":
+            yield file.filename
+
+
+def check_news_file(pr):
+    return any(map(lambda file_name: fnmatch(file_name, "news/*.rst"), get_added_files(pr)))
+
+
+def get_pr_number():
+    number = os.environ["PR_NUMBER"]
+    if not number:
+        raise Exception(f"Pull request number is not found `PR_NUMBER={number}")
+    return int(number)
+
+
+def get_old_comment(pr: PullRequest.PullRequest):
+    for comment in pr.get_issue_comments():
+        if ("github-actions" in comment.user.login) and ("No news item is found" in comment.body):
+            return comment
+
+
+def main():
+    # using an access token
+    gh = Github(os.environ["GITHUB_TOKEN"])
+    repo = gh.get_repo(os.environ["GITHUB_REPOSITORY"])
+    pr = repo.get_pull(get_pr_number())
+    has_news_added = check_news_file(pr)
+    old_comment = get_old_comment(pr)
+
+    if old_comment:
+        print("Found an existing comment from bot")
+        if has_news_added:
+            print("Delete warning from bot, since news items is added.")
+            old_comment.delete()
+    elif not has_news_added:
+        print("No news item found")
+
+        pr.create_issue_comment(
+            """\
+**Warning!** No news item is found for this PR. If this is an user facing change/feature/fix,
+ please add a news item by copying the format from `news/TEMPLATE.rst`.
+"""
+        )
+        assert False
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes https://github.com/Billingegroup/cookiecutter/issues/95

CI fails when no news item is provided with the following warning:

<img width="937" alt="Screenshot 2024-09-10 at 5 50 16 PM" src="https://github.com/user-attachments/assets/d0f8929d-37b6-446e-9002-6a5182bec8b4">


