### PR TITLE
Update setuptools-git-versioning >= 2.0

### DIFF
--- a/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=62.0", "setuptools-git-versioning<2"]
+requires = ["setuptools>=62.0", "setuptools-git-versioning>=2.0"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
v2.0.0 is now available - https://setuptools-git-versioning.readthedocs.io/en/stable/install.html

Should be merged after https://github.com/conda-forge/diffpy.structure-feedstock/pull/17 is merged and tested where `setuptools-git-versioning >= 2.0` is used.

