### PR TITLE
Add unit test for __version__.py

### DIFF
--- a/{{ cookiecutter.repo_name }}/tests/test_version.py
+++ b/{{ cookiecutter.repo_name }}/tests/test_version.py
@@ -1,0 +1,10 @@
+"""Unit tests for __version__.py
+"""
+
+import {{ cookiecutter.package_dist_name }}
+
+
+def test_package_version():
+    """Ensure the package version is defined and not set to the initial placeholder."""
+    assert hasattr({{ cookiecutter.package_dist_name }}, "__version__")
+    assert {{ cookiecutter.package_dist_name }}.__version__ != "0.0.0"


### PR DESCRIPTION
Closes: https://github.com/Billingegroup/staged-recipes-cookiecutter/issues/20

Tested locally that we have a new file `tests/test_version.py` using `diffpy.structure` as an input:

```python
"""Unit tests for __version__.py
"""

import diffpy.structure


def test_package_version():
    """Ensure the package version is defined and not set to the initial placeholder."""
    assert hasattr(diffpy.structure, "__version__")
    assert diffpy.structure.__version__ != "0.0.0"
```

The cookiecuttered content cross-checked with diffpy.structure's `test_version.py` file manually included below:

https://github.com/diffpy/diffpy.structure/pull/103/files#diff-9ab45dbf39b5b413329c431076d5c7962fc6397a606213310fa96a22b1216109