### PR TITLE
Use package dir name for install check in readme

### DIFF
--- a/{{ cookiecutter.repo_name }}/README.rst
+++ b/{{ cookiecutter.repo_name }}/README.rst
@@ -67,7 +67,7 @@ The following creates and activates a new environment named ``{{ cookiecutter.pa
 
 To confirm that the installation was successful, type ::
 
-        python -c "import {{ cookiecutter.package_dist_name }}; print({{ cookiecutter.package_dist_name }}.__version__)"
+        python -c "import {{ cookiecutter.package_dir_name }}; print({{ cookiecutter.package_dir_name }}.__version__)"
 
 The output should print the latest version displayed on the badges above.
 


### PR DESCRIPTION
Tested locally:

For `bg-mpl-stylesheets`:

```
To confirm that the installation was successful, type ::

        python -c "import bg_mpl_stylesheets; print(bg_mpl_stylesheets.__version__)"
```

For `diffpy.snmf`: 

```
To confirm that the installation was successful, type ::

        python -c "import diffpy.snmf; print(diffpy.snmf.__version__)"
```
