### PR TITLE
Add Getting Started section and description of bg-cookiecutter in index.rst

### DIFF
--- a/doc/source/cookiecutter_guide.rst
+++ b/doc/source/cookiecutter_guide.rst
@@ -2,9 +2,14 @@
 
 .. index:: cookiecutter_guide
     
+
+.. _cookiecutter-title:
+
 ===============================
-How to migrate existing package
+How to cookiecut Python package
 ===============================
+
+.. _cookiecutter-installation:
 
 The following creates and activates a new environment named ``cookiecutter_env`` ::
 
@@ -86,8 +91,12 @@ WARNINGS
 
 17. Only proceed to the next section after addressing all PRs relevant to the pre-commit workflow.
 
-2. Cookiecutter workflow
-------------------------
+.. _cookiecutter-workflow-main:
+
+1. Cookiecutter main workflow
+-----------------------------
+
+Please follow the instructions in the `installation <_cookiecutter-installation>`_ section.
 
 1. Type ``cookiecutter https://github.com/billingegroup/cookiecutter`` inside the package directory.
 
@@ -116,6 +125,8 @@ WARNINGS
    11. Is a GUI application, run 'HEADLESS' tests (default: false): (default). If it is a GUI package, change this to ``true``.
 
    12. Enter value for workflow 'VERSION' (default: v0): (default). Version of the workflow to use.
+
+If you are starting a new project, you can skip the following sections and proceed to the API documentation workflow below.
 
 4. cd into the new ``diffpy.<package_name>/`` directory (e.g., in our example ``pwd`` would return ``~/dev/diffpy.pdfmorph/diffpy.pdfmorph``) (we will refer to the nested directory as the "**cookiecutter**" directory and ``~/dev/diffpy.pdfmorph/`` as the "**main**" directory).
 
@@ -153,6 +164,8 @@ WARNINGS
 
     2. Most ``pkg_resources`` deprecation warnings will be fixed by cookiecutter, but if you are in a diffpy package using unittests and see this warning you can fix them by replacing ``from pkg_resources import resource_filename`` with ``from importlib import resources`` and change ``path = resource_filename(__name__, p)`` to ``path = str(resources.files(__name__).joinpath(p))``. If you see ``collected 0 items no tests ran`` you might want to rename testing files as ``test_*.py``. Refer to the [migration guide](https://importlib-resources.readthedocs.io/en/latest/migration.html).
 
+.. _cookiecutter-workflow-api:
+
 3. API documentation workflow
 -----------------------------
 
@@ -179,8 +192,23 @@ In the case of ``PDFmorph``, this was done by adding ``autodoc_mock_imports = ["
 Congratulations! You may now commit the changes made by ``auto_api.py`` (and yourself) and push this commit to the cloud!
 Make a PR! It will be merged, trust!
 
-4. Codecov token setup for the repository
------------------------------------------
+4. Final sign-off
+-----------------
+
+1. For the ``cookierelease`` activity make a ``<branchname>.rst`` file by copying ``TEMPLATE.rst`` in the news folder and under "fixed" put ``Repo structure modified to the new diffpy standard``
+   
+2. If a new Python version has been added under "added" add `Python 3.xx, 3,xx support`. If a previous version has been removed, under "fixed", add a new item `Python 3.xx, 3.xx, support`.
+
+3. Check the `README` and make sure that all parts have been filled in and all links resolve correctly.
+
+4. Run through the documentation online and do the same, fix any last typos and make all the links work. To do this the documentation must have been correctly built on a merge to main and enabled on the github.io website. Instructions are [here](https://gitlab.thebillingegroup.com/resources/group-wiki/-/wikis/Maintaining-and-Deploying-Documentation).
+
+5. When you are are happy to sign off on the release send a Slack message to Simon saying something like "`OK to release diffpy.<package-name>`"
+
+6. Make sure that the codecov secret is set in the GH actions repository secrets.
+
+Appendix 1. Codecov token setup for the repository
+--------------------------------------------------
 
 For each PR, we use ``Codecov`` to report the test coverage percentage change as shown below.
 
@@ -217,26 +245,8 @@ To do so, the repository owner (Prof. Billinge) needs to provide a ``CODECOV_TOK
 
 8. Done. The Codecov token is now set up for the repository. A comment will be generated on each PR with the Codecov status automatically.
 
-Congratulations! You may now commit the changes made by ``auto_api.py`` (and yourself) and push this commit to the GitHub repository!
-
-
-4. Final sign-off
------------------
-
-1. For the ``cookierelease`` activity make a ``<branchname>.rst`` file by copying ``TEMPLATE.rst`` in the news folder and under "fixed" put ``Repo structure modified to the new diffpy standard``
-   
-2. If a new Python version has been added under "added" add `Python 3.xx, 3,xx support`. If a previous version has been removed, under "fixed", add a new item `Python 3.xx, 3.xx, support`.
-
-3. Check the `README` and make sure that all parts have been filled in and all links resolve correctly.
-
-4. Run through the documentation online and do the same, fix any last typos and make all the links work. To do this the documentation must have been correctly built on a merge to main and enabled on the github.io website. Instructions are [here](https://gitlab.thebillingegroup.com/resources/group-wiki/-/wikis/Maintaining-and-Deploying-Documentation).
-
-5. When you are are happy to sign off on the release send a Slack message to Simon saying something like "`OK to release diffpy.<package-name>`"
-
-6. Make sure that the codecov secret is set in the GH actions repository secrets.
-
 Appendix 2. How to configure pre-commit CI via GitHub Apps
----------------------------------------------------
+----------------------------------------------------------
 
 ``Pre-commit CI`` is available as a GitHub app that executes pre-commit hooks in each pull request, as shown in the image below. While it is recommended to run ``precommit run --all-files`` locally before making a PR, this GitHub app will automatically attempt to lint code and format docstrings according to the hooks provided in ``.pre-commit-config.yaml``. If all passes, it will give you a green checkmark as shown below.
 
@@ -249,8 +259,8 @@ To configure ``pre-commit CI``, follow the simple steps below:
 2. Select the repository(s).
 3. Done!
 
-Appendix 3. How to test your package locally before making a PR
---------------------------------------------------------------
+Appendix 3. How to test your package locally
+--------------------------------------------
 
 We will use the ``diffpy.utils`` package as an example. In the package directory, follow these instructions:
 

--- a/doc/source/frequently_asked_questions.rst
+++ b/doc/source/frequently_asked_questions.rst
@@ -2,6 +2,8 @@
 
 .. index:: frequently_asked_questions
 
+.. _frequently_asked_questions:
+
 ================================
 Frequently asked questions (FAQ)
 ================================
@@ -40,6 +42,11 @@ To ignore a specific file extension, add ``*.ext`` to the ``skip`` section under
 
 Release
 -------
+
+How is the package version set and retrieved?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In ``pyproject.toml``, the ``setuptools-git-versioning`` tool is used to dynamically retrieve the version based on the latest tag in the repository. The latest tag is pushed during the release workflow. The dynamically parsed version is globally accessible, via ``<package-name>.__version__``.
 
 How do I include/exclude files in PyPI release?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -140,3 +147,14 @@ For the current GitHub CI for checking a news item, ``pull_request_target`` is u
 - ``pull_request_target``: This event grants the ``GITHUB_TOKEN`` write permissions, enabling it to perform actions that modify the repository, such as posting comments, updating pull request statuses, or merging code. The news CI creates a comment when an additional news ``.rst`` is not found under the ``news`` folder. Hence, ``pull_request_target`` is used.
 
 Another key difference is that with ``pull_request_target``, the ``.yml`` file **must already be merged** in the base branch at the time the pull request is opened or updated. For more, please refer to `GitHub docs <https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target>`_.
+
+
+Dependency management
+---------------------
+
+Why are both pip.txt and conda.txt provided?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Our preferred choice for installing the cookiecuttered package is as a Conda package, as outlined in the template ``README.rst`` file. With Conda, the end user can install all associated dependencies by running ``conda create --name new_env <package-name>``. Additionally, the environment is tested via conda-forge CI before the Conda package is released, which helps ensure the package's compatibility with its dependencies. Hence, we list conda package dependencies in ``conda.txt``.
+
+However, we also want to allow users to install the package via ``pip``. To support this, we provide a separate file for pip dependencies, ``pip.txt``. In most cases, the dependencies listed in ``conda.txt`` and ``pip.txt`` will be identical. However, there can be exceptions. For example, ``matplotlib-base`` is preferred for Conda installations, while ``matplotlib`` is used for pip installations.

--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -21,4 +21,3 @@ Are you here for release?
 -------------------------
 
 You already have a bg-cookiecuttered package. Do you want to release your package to ``GitHub``, ``PyPI``, and ``conda-forge`` by creating a tag to your GitHub repository? Start from :ref:`here <release_guide>`.
-

--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -1,0 +1,24 @@
+:tocdepth: -1
+
+.. index:: getting_started
+
+.. _getting_started:
+
+===============
+Getting started
+===============
+
+Are you here for cookiecutting?
+-------------------------------
+
+1. Do you already have a Python package you want to standardize with ``bg-cookiecutter``? Please follow the full instructions :ref:`here <cookiecutter-title>`.
+
+2. Do you already have a bg-cookiecuttered package and you want to use the latest version? Please follow the instructions in :ref:`here <cookiecutter-workflow-main>`.
+
+3. Do you want to start a new Python repository with ``bg-cookiecutter``? Start from the Cookiecutter workflow section :ref:`here <cookiecutter-workflow-main>`.
+
+Are you here for release?
+-------------------------
+
+You already have a bg-cookiecuttered package. Do you want to release your package to ``GitHub``, ``PyPI``, and ``conda-forge`` by creating a tag to your GitHub repository? Start from :ref:`here <release_guide>`.
+

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -9,8 +9,8 @@
 
 Welcome to Billinge Group's Python cookiecutter documentation!
 
-Benefits
---------
+How is ``bg-cookiecutter`` useful?
+----------------------------------
 
 ``bg-cookiecutter`` is a Python project template designed for scientific software development. The template allows you to save time and prioritize the scientific content of your package by providing the following features:
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -4,25 +4,78 @@
 
 .. |title| replace:: bg-cookiecutter documentation
 
-bg-cookiecutter - Python package standard in the Billinge Research Group
-
 | Software version |release|.
 | Last updated |today|.
+
+Welcome to Billinge Group's Python cookiecutter documentation!
+
+Benefits
+--------
+
+``bg-cookiecutter`` is a Python project template designed for scientific software development. The template allows you to save time and prioritize the scientific content of your package by providing the following features:
+
+- Automated `PEP8 <https://peps.python.org/pep-0008/>`_ and `PEP256 <https://peps.python.org/pep-0256/>`_ standard checks.
+- Automated PyPI/GitHub release, testing, documentation, and CHANGELOG updates.
+- Streamlined package release workflow with a checklist.
+- Latest Python version support compatible with `SPEC0 <https://scientific-python.org/specs/spec-0000/>`_.
+- Rich README template containing badges, installation, support, and contribution guide.
+- Automatic spelling check, linting for .json, .yml, and .md files.
+
+For more technical details, it includes:
+
+- Pull requests with coverage reports using ``Codecov`` and checks with ``pre-commit CI``.
+- Namespace package support, e.g., ``import diffpy.utils``.
+- conda-package ``meta.yaml`` generation with a template.
+- Support for non-pure Python package releases with ``cibuildwheel``.
+- Support for headless GitHub CI testing for GUI applications.
+- Reusable GitHub Actions workflows located in `Billingegroup/release-scripts <https://github.com/Billingegroup/release-scripts/tree/main/.github/workflows>`_.
+
+How do I get started?
+---------------------
+
+Please visit the :ref:`Getting started <getting_started>` page to learn how to navigate the documentation!
+
+How do I receive support?
+-------------------------
+
+If you have any questions or have trouble, please read the :ref:`Frequently asked questions (FAQ) <frequently_asked_questions>` section to see if your questions have already been answered. If there aren't answers available, please create an issue. The team will reach out.
+
+How can I contribute?
+---------------------
+
+Do you have any new features? Please make an issue via the GitHub issue tracker for further discussions. For a minor typo or grammatically incorrect sentence, please make a pull request. Before making a PR, please run ``pre-commit run --all-files`` to ensure the code is formatted.
+
+Who are using ``bg-cookiecutter``?
+----------------------------------
+
+The full list of packages is as follows:
+
+- `diffpy.pdffit2 <https://github.com/diffpy/diffpy.pdffit2>`_
+- `diffpy.fourigui <https://github.com/diffpy/diffpy.fourigui>`_
+- `diffpy.pdfgui <https://github.com/diffpy/diffpy.pdfgui>`_
+- `diffpy.utils <https://github.com/diffpy/diffpy.utils>`_
+- `diffpy.structure <https://github.com/diffpy/diffpy.structure>`_
+- `diffpy.labpdfproc <https://github.com/diffpy/diffpy.labpdfproc>`_
+- `diffpy.pdfmorph <https://github.com/diffpy/diffpy.pdfmorph>`_
+- `diffpy.snmf <https://github.com/diffpy/diffpy.snmf>`_
+- `diffpy.srmise <https://github.com/diffpy/diffpy.srmise>`_
+- `regolith <https://github.com/regro/regolith>`_
+- `bg-mpl-stylesheets <https://github.com/Billingegroup/bg-mpl-stylesheets>`_
 
 =======
 Authors
 =======
 
-bg-cookiecutter is developed by Billinge Group
-and its community contributors.
+bg-cookiecutter is developed by Billinge Group and its community contributors.
 
-For a detailed list of contributors see
+For a detailed list of contributors, see
 https://github.com/Billingegroup/cookiecutter/graphs/contributors.
 
 ================
 Acknowledgements
 ================
 
+The Billinge Group's cookiecutter has been modified from the
 The Billinge Group's cookiecutter has been modified from the NSLS-II scientific cookiecutter: https://github.com/nsls-ii/scientific-python-cookiecutter
 
 =================
@@ -31,6 +84,7 @@ Table of contents
 .. toctree::
    :maxdepth: 2
 
+   getting_started
    cookiecutter_guide
    release_guide
    conda_forge_guide

--- a/doc/source/release_guide.rst
+++ b/doc/source/release_guide.rst
@@ -2,6 +2,8 @@
 
 .. index:: release_guide
     
+.. _release_guide:
+
 ===============================
 How to release Python package
 ===============================

--- a/news/getting-started.rst
+++ b/news/getting-started.rst
@@ -1,0 +1,25 @@
+**Added:**
+
+* Getting started page in documentation
+* FAQ section on why both pip.txt and conda.txt added
+* FAQ section on how version is set and retrieved dynamically
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
# Index.rst page
- Added potential benefits and features (both non-technical and technical)

<img width="870" alt="Screenshot 2024-12-26 at 11 56 45 AM" src="https://github.com/user-attachments/assets/94930baa-4997-4887-a950-94e348905b8a" />

# Getting started page
- Categorize into two groups 1) here for cookiecut 2) here for release

<img width="747" alt="Screenshot 2024-12-26 at 11 57 27 AM" src="https://github.com/user-attachments/assets/5fc68ad5-77f6-4119-98c9-2ad57e72172c" />
